### PR TITLE
Bug: Refund's OrderAdjustments field is an array and not a reference.

### DIFF
--- a/fulfillment_service.go
+++ b/fulfillment_service.go
@@ -8,11 +8,14 @@ const fulfillmentServicesBasePath = "fulfillment_services"
 
 type FulfillmentSvcService interface {
 	List(interface{}) ([]FulfillmentSvc, error)
+	Get(int64, interface{}) (FulfillmentSvc, error)
 }
 
 type FulfillmentSvcServiceOp struct {
 	client *Client
 }
+
+var _ FulfillmentSvcService = &FulfillmentSvcServiceOp{}
 
 type FulfillmentSvc struct {
 	ID                     int64  `json:"id"`
@@ -32,6 +35,7 @@ type FulfillmentSvc struct {
 
 type FulfillmentSvcsResource struct {
 	FulfillmentSvcs []FulfillmentSvc `json:"fulfillment_services"`
+	FulfillmentSvc  FulfillmentSvc   `json:"fulfillment_service"`
 }
 
 // List shipping zones
@@ -40,4 +44,11 @@ func (s *FulfillmentSvcServiceOp) List(options interface{}) ([]FulfillmentSvc, e
 	resource := new(FulfillmentSvcsResource)
 	err := s.client.Get(path, resource, options)
 	return resource.FulfillmentSvcs, err
+}
+
+func (s *FulfillmentSvcServiceOp) Get(id int64, options interface{}) (FulfillmentSvc, error) {
+	path := fmt.Sprintf("%s/%d.json", fulfillmentServicesBasePath, id)
+	resource := new(FulfillmentSvcsResource)
+	err := s.client.Get(path, resource, options)
+	return resource.FulfillmentSvc, err
 }

--- a/refund.go
+++ b/refund.go
@@ -20,17 +20,17 @@ type RefundServiceOp struct {
 }
 
 type Refund struct {
-	ID                int64             `json:"id"`
-	AdminGraphqlAPIID string            `json:"admin_graphql_api_id"`
-	CreatedAt         *time.Time        `json:"created_at"`
-	Note              string            `json:"note"`
-	OrderID           int64             `json:"order_id"`
-	ProcessedAt       *time.Time        `json:"processed_at"`
-	Restock           bool              `json:"restock"`
-	UserID            int64             `json:"user_id"`
-	OrderAdjustments  *OrderAdjustments `json:"order_adjustments"`
-	Transactions      []*Transaction    `json:"transactions"`
-	RefundLineItems   []*RefundLineItem `json:"refund_line_items"`
+	ID                int64               `json:"id"`
+	AdminGraphqlAPIID string              `json:"admin_graphql_api_id"`
+	CreatedAt         *time.Time          `json:"created_at"`
+	Note              string              `json:"note"`
+	OrderID           int64               `json:"order_id"`
+	ProcessedAt       *time.Time          `json:"processed_at"`
+	Restock           bool                `json:"restock"`
+	UserID            int64               `json:"user_id"`
+	OrderAdjustments  []*OrderAdjustments `json:"order_adjustments"`
+	Transactions      []*Transaction      `json:"transactions"`
+	RefundLineItems   []*RefundLineItem   `json:"refund_line_items"`
 }
 
 type OrderAdjustments struct {


### PR DESCRIPTION
Serialization bug on Refund struct.

Cause:
Existing order_adjustments field is a reference of 1 object instead of an array.

Expectation:
According to [Refund resource](https://shopify.dev/api/admin-rest/2022-04/resources/refund#resource-object), order_adjustments = A list of order adjustments attached to the refund. Order adjustments are generated to account for refunded shipping costs and differences between calculated and actual refund amounts.